### PR TITLE
Remove extra reporting in RSpec3

### DIFF
--- a/lib/rspec-gc-control/base_text_formatter.rb
+++ b/lib/rspec-gc-control/base_text_formatter.rb
@@ -1,45 +1,50 @@
+require 'rspec/core/version'
 require 'rspec/core/formatters/base_formatter'
 
-module RSpec
-  module Core
-    module Formatters
+if defined?(::RSpec::Core) && ::RSpec::Core::Version::STRING < '3.0.0'
 
-      class BaseTextFormatter < BaseFormatter
+  module RSpec
+    module Core
+      module Formatters
 
-        # Overridden version of this method, to include output about forced GC
-        # count and duration, if explicit GC control is enabled.
-        def dump_summary(duration, example_count, failure_count, pending_count)
-          super(duration, example_count, failure_count, pending_count)
+        class BaseTextFormatter < BaseFormatter
 
-          gc_times  = examples.
-                        map { |ex| ex.execution_result[:gc_time] }.
-                        select { |t| t && (t > 0) }
-          gc_count  = gc_times.count
-          gc_time   = gc_times.reduce(:+)
+          # Overridden version of this method, to include output about forced GC
+          # count and duration, if explicit GC control is enabled.
+          def dump_summary(duration, example_count, failure_count, pending_count)
+            super(duration, example_count, failure_count, pending_count)
 
-          dump_summary_to_output(duration, gc_time, gc_count, example_count,
-                                 failure_count, pending_count)
-        end
+            gc_times  = examples.
+                          map { |ex| ex.execution_result[:gc_time] }.
+                          select { |t| t && (t > 0) }
+            gc_count  = gc_times.count
+            gc_time   = gc_times.reduce(:+)
 
-        protected
-
-        def dump_summary_to_output(duration, gc_time, gc_count, example_count,
-                           failure_count, pending_count)
-          # Don't print out profiled info if there are failures, it just
-          # clutters the output.
-          dump_profile if profile_examples? && failure_count == 0
-          output.print "\nFinished in #{format_duration(duration)}"
-
-          if(gc_count > 0)
-            output.print " (including #{gc_count} forced GC cycle(s), totalling #{format_duration(gc_time)})"
+            dump_summary_to_output(duration, gc_time, gc_count, example_count,
+                                   failure_count, pending_count)
           end
 
-          output.print "\n"
-          output.puts colorise_summary(summary_line(example_count, failure_count, pending_count))
-          dump_commands_to_rerun_failed_examples
-        end
+          protected
 
+          def dump_summary_to_output(duration, gc_time, gc_count, example_count,
+                             failure_count, pending_count)
+            # Don't print out profiled info if there are failures, it just
+            # clutters the output.
+            dump_profile if profile_examples? && failure_count == 0
+            output.print "\nFinished in #{format_duration(duration)}"
+
+            if(gc_count > 0)
+              output.print " (including #{gc_count} forced GC cycle(s), totalling #{format_duration(gc_time)})"
+            end
+
+            output.print "\n"
+            output.puts colorise_summary(summary_line(example_count, failure_count, pending_count))
+            dump_commands_to_rerun_failed_examples
+          end
+
+        end
       end
     end
   end
+
 end

--- a/rspec-gc-control.gemspec
+++ b/rspec-gc-control.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rspec-gc-control"
-  s.version = "1.0.1airbnb1"
+  s.version = "1.0.1airbnb2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Jon Frisby"]


### PR DESCRIPTION
@clintkelly

Let's remove the reporting patch first to unblock us to RSpec 3. We can investigate how to add it back later.
